### PR TITLE
Increase length of title and url for entry

### DIFF
--- a/priv/repo/migrations/20221201161522_modify_title_to_be_larger.exs
+++ b/priv/repo/migrations/20221201161522_modify_title_to_be_larger.exs
@@ -1,0 +1,9 @@
+defmodule ExRss.Repo.Migrations.ModifyTitleToBeLarger do
+  use Ecto.Migration
+
+  def change do
+    alter table(:entries) do
+      modify :title, :string, size: 1024, from: :string
+    end
+  end
+end

--- a/priv/repo/migrations/20221202100358_modify_url_to_be_larger.exs
+++ b/priv/repo/migrations/20221202100358_modify_url_to_be_larger.exs
@@ -1,0 +1,9 @@
+defmodule ExRss.Repo.Migrations.ModifyUrlToBeLarger do
+  use Ecto.Migration
+
+  def change do
+    alter table(:entries) do
+      modify :url, :string, size: 1024, from: :string
+    end
+  end
+end


### PR DESCRIPTION
I found a feed that hat URLs larger than 256 characters which let the application crash with a SQL exception. This is a quick fix that will prevent the application from crashing in this specific case, but it does not yet deal with the larger issue of proper error handling and not crashing in the first place.
