### PR TITLE
Add date format to parser

### DIFF
--- a/lib/ex_rss/entry.ex
+++ b/lib/ex_rss/entry.ex
@@ -71,10 +71,15 @@ defmodule ExRss.Entry do
     "%Y-%m-%dT%H:%M:%S.%L%:z",
     # 2019-01-17T00:00:00Z
     "%Y-%m-%dT%H:%M:%SZ",
+    # Beware the difference between trailing `%z` and `%:z`.
+    # 2022-07-09T15:00:00+0000
+    "%Y-%m-%dT%H:%M:%S%z",
+
     # Internet date/time format as specified by RFC 3339
     # See https://tools.ietf.org/html/rfc3339
     # 2018-01-13T19:05:08+00:00
     "%Y-%m-%dT%H:%M:%S%:z",
+
     # 2021-11-06
     # Make sure this comes after other formats that this format is a substring
     # of.

--- a/lib/ex_rss/feed_adder.ex
+++ b/lib/ex_rss/feed_adder.ex
@@ -150,6 +150,8 @@ defmodule ExRss.FeedAdder do
     %{posts: 3, seconds: 97362}
   """
   def extract_frequency_info(raw_feed) do
+    posts = Enum.count(raw_feed.entries)
+
     entries =
       raw_feed.entries
       |> Enum.flat_map(fn e ->
@@ -162,9 +164,9 @@ defmodule ExRss.FeedAdder do
     try do
       {min_date, max_date} = Enum.min_max_by(entries, &Timex.to_gregorian_microseconds/1)
 
-      %{posts: Enum.count(entries), seconds: Timex.diff(max_date, min_date, :seconds)}
+      %{posts: posts, seconds: Timex.diff(max_date, min_date, :seconds)}
     rescue
-      Enum.EmptyError -> nil
+      Enum.EmptyError -> %{posts: posts, seconds: :not_available}
     end
   end
 end

--- a/lib/ex_rss_web/feed_live/new.ex
+++ b/lib/ex_rss_web/feed_live/new.ex
@@ -57,6 +57,9 @@ defmodule ExRssWeb.FeedLive.New do
     {:noreply, socket}
   end
 
+  def format_frequency(%{seconds: :not_available, posts: posts}),
+    do: "#{posts} posts, no frequency info available"
+
   def format_frequency(%{seconds: seconds, posts: posts}) do
     duration =
       if seconds < 2 * 86400 do

--- a/test/ex_rss/entry_test.exs
+++ b/test/ex_rss/entry_test.exs
@@ -12,6 +12,7 @@ defmodule ExRss.EntryTest do
     assert {:ok, _} = Entry.parse_time("2018-08-22T10:07:06.121Z")
     assert {:ok, _} = Entry.parse_time("2020-05-03T13:10:00.000-06:00")
     assert {:ok, _} = Entry.parse_time("2019-01-17T00:00:00Z")
+    assert {:ok, _} = Entry.parse_time("2022-07-09T15:00:00+0000")
     assert {:ok, _} = Entry.parse_time("06 Sep 2017 12:00 +0000")
     assert {:ok, _} = Entry.parse_time("2021-11-06")
   end

--- a/test/ex_rss/feed_adder_test.exs
+++ b/test/ex_rss/feed_adder_test.exs
@@ -142,6 +142,8 @@ defmodule ExRss.FeedAdderTest do
   test "doesn’t extract frequency info when no publication dates are given" do
     {:ok, raw_feed, _} = FeederEx.parse(@rss_whithout_pubdate)
 
-    assert is_nil(FeedAdder.extract_frequency_info(raw_feed))
+    frequency_info = FeedAdder.extract_frequency_info(raw_feed)
+
+    assert %{posts: 1, seconds: :not_available} = frequency_info
   end
 end


### PR DESCRIPTION
- Add fallback when dates can’t be parsed
- Add date format to parser
